### PR TITLE
feat: added dove's harp

### DIFF
--- a/buffs_json/use_items.json
+++ b/buffs_json/use_items.json
@@ -1223,6 +1223,13 @@
         "type": "item",
         "icon": "NWN-Buff-Watcher/graphics/ghostly_visage.png"
     },
+    "uses Dove's Harp": {
+        "name": "CD Greater Restoration",
+        "duration": "240",
+        "caster_level": "1",
+        "type": "item",
+        "icon": "NWN-Buff-Watcher/graphics/greater_resto_cd.png"
+    },
     "uses Bardic Harp": {
         "name": "Eagle's Splendor",
         "duration": "360",


### PR DESCRIPTION
Working on #5 
Just adding the Dove's Harp resto cooldown for now
Similar to #42, all the harp stuff can't track duration
And its for piddly stuff like amplify versus lore... just making them what I think is most common for now