### PR TITLE
bug: use item fix

### DIFF
--- a/buffs_json/use_items.json
+++ b/buffs_json/use_items.json
@@ -1073,7 +1073,7 @@
 
 
 
-    "uses item's special power": {
+    "uses item's special power.": {
         "name": "Special Power",
         "duration": "300",
         "caster_level": "5",


### PR DESCRIPTION
fixes #68 
Just had to add a "." to the end of the use item check in the json, since it's the only "use" item that has a period, everything else just ends without any punctuation, that's what threw things off